### PR TITLE
Fix some required -j target rules delete bug when delete source/destinat...

### DIFF
--- a/scripts/vyatta-update-dst-nat.pl
+++ b/scripts/vyatta-update-dst-nat.pl
@@ -40,7 +40,19 @@ sub raw_cleanup {
   ipt_disable_conntrack('iptables', 'NAT_CONNTRACK');
 }
 
+my $all_deleted = 1;
+
 my $config = new Vyatta::Config;
+
+$config->setLevel("nat source rule");
+my %rules_src = $config->listNodeStatus();
+my $rule_src;
+for $rule_src (keys %rules_src) {
+  if ($rules_src{$rule_src} ne "deleted") {
+    $all_deleted = 0;
+  }
+}
+
 $config->setLevel($CONFIG_LEVEL." rule");
 my %rules = $config->listNodeStatus();
 my $rule;
@@ -69,7 +81,6 @@ system("$IPTABLES -t nat -L -n >& /dev/null");
 # we have some nat rule(s). make sure conntrack is enabled.
 ipt_enable_conntrack('iptables', 'NAT_CONNTRACK');
 
-my $all_deleted = 1;
 for $rule (@rule_keys) {
   print OUT "$rule: $rules{$rule}\n";
   my $tmp = `iptables -L -nv --line -t nat`;

--- a/scripts/vyatta-update-src-nat.pl
+++ b/scripts/vyatta-update-src-nat.pl
@@ -40,7 +40,19 @@ sub raw_cleanup {
   ipt_disable_conntrack('iptables', 'NAT_CONNTRACK');
 }
 
+my $all_deleted = 1;
+
 my $config = new Vyatta::Config;
+
+$config->setLevel("nat destination rule");
+my %rules_dst = $config->listNodeStatus();
+my $rule_dst;
+for $rule_dst (keys %rules_dst) {
+  if ($rules_dst{$rule_dst} ne "deleted") {
+    $all_deleted = 0;
+  }
+}
+
 $config->setLevel($CONFIG_LEVEL." rule");
 my %rules = $config->listNodeStatus();
 my $rule;
@@ -69,7 +81,6 @@ system("$IPTABLES -t nat -L -n >& /dev/null");
 # we have some nat rule(s). make sure conntrack is enabled.
 ipt_enable_conntrack('iptables', 'NAT_CONNTRACK');
 
-my $all_deleted = 1;
 for $rule (@rule_keys) {
   print OUT "$rule: $rules{$rule}\n";
   my $tmp = `iptables -L -nv --line -t nat`;


### PR DESCRIPTION
These rules must be exists in raw table when source nat or destination nat is enabled.

```
-A PREROUTING -j VYATTA_CT_HELPER
-A PREROUTING -j NAT_CONNTRACK
-A OUTPUT -j VYATTA_CT_HELPER
-A OUTPUT -j NAT_CONNTRACK
-A NAT_CONNTRACK -j ACCEPT
```

But, when you delete one of pair completely in the state of exists both, these rules will be deleted despite the required.

See below...

```
[edit]
vyos@vyos# show nat
Configuration under specified path is empty
[edit]
vyos@vyos# set nat source rule 1 outbound-interface eth0
[edit]
vyos@vyos# set nat source rule 1 translation address masquerade 
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# sudo iptables-save > /tmp/1         
[edit]
vyos@vyos# set nat destination rule 1 inbound-interface eth0
[edit]
vyos@vyos# set nat destination rule 1 translation address 172.16.1.1
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# delete nat destination 
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# sudo iptables-save > /tmp/2
[edit]
vyos@vyos# diff -u /tmp/1 /tmp/2
--- /tmp/1  2014-05-30 02:04:24.657329323 +0000
+++ /tmp/2  2014-05-30 02:05:11.837330363 +0000
... snip ...
@@ -37,30 +37,24 @@
 -A VYATTA_PRE_FW_IN_HOOK -j RETURN
 -A VYATTA_PRE_FW_OUT_HOOK -j RETURN
 COMMIT
-# Completed on Fri May 30 02:04:24 2014
-# Generated by iptables-save v1.4.12.2 on Fri May 30 02:04:24 2014
+# Completed on Fri May 30 02:05:11 2014
+# Generated by iptables-save v1.4.12.2 on Fri May 30 02:05:11 2014
 *raw
-:PREROUTING ACCEPT [0:0]
-:OUTPUT ACCEPT [0:0]
-:NAT_CONNTRACK - [0:0]
+:PREROUTING ACCEPT [28:2096]
+:OUTPUT ACCEPT [16:1492]
 :VYATTA_CT_HELPER - [0:0]
 :VYATTA_CT_IGNORE - [0:0]
 :VYATTA_CT_OUTPUT_HOOK - [0:0]
 :VYATTA_CT_PREROUTING_HOOK - [0:0]
 :VYATTA_CT_TIMEOUT - [0:0]
 -A PREROUTING -j VYATTA_CT_IGNORE
--A PREROUTING -j VYATTA_CT_HELPER
 -A PREROUTING -j VYATTA_CT_TIMEOUT
 -A PREROUTING -j VYATTA_CT_PREROUTING_HOOK
--A PREROUTING -j NAT_CONNTRACK
 -A PREROUTING -j NOTRACK
 -A OUTPUT -j VYATTA_CT_IGNORE
--A OUTPUT -j VYATTA_CT_HELPER
 -A OUTPUT -j VYATTA_CT_TIMEOUT
 -A OUTPUT -j VYATTA_CT_OUTPUT_HOOK
--A OUTPUT -j NAT_CONNTRACK
 -A OUTPUT -j NOTRACK
--A NAT_CONNTRACK -j ACCEPT
 -A VYATTA_CT_HELPER -p tcp -m tcp --dport 1525 -j CT --helper tns
 -A VYATTA_CT_HELPER -p tcp -m tcp --dport 1521 -j CT --helper tns
 -A VYATTA_CT_HELPER -p udp -m udp --dport 111 -j CT --helper rpc
@@ -71,4 +65,4 @@
 -A VYATTA_CT_PREROUTING_HOOK -j RETURN
 -A VYATTA_CT_TIMEOUT -j RETURN
 COMMIT
-# Completed on Fri May 30 02:04:24 2014
+# Completed on Fri May 30 02:05:11 2014
```
