### PR TITLE
Fix protocol negation in NAT (like it is done in Vyatta::IpTables::Rule)

### DIFF
--- a/lib/Vyatta/DstNatRule.pm
+++ b/lib/Vyatta/DstNatRule.pm
@@ -158,8 +158,10 @@ sub rule_str {
   if (defined($self->{_proto})) {
     my $str = $self->{_proto};
     my $negate ="";
-    $negate = "!" if (m/^\!(.*)$/);
-    $str =~ s/^\!(.*)$/ $1/;
+    if ($str =~ /^\!(.*)$/) {
+      $str    = $1;
+      $negate = "!";
+    }
     if ($str eq 'tcp_udp') {
       $tcp_and_udp = 1;
       $rule_str .= " -p tcp "; # we'll add the '-p udp' to 2nd rule later

--- a/lib/Vyatta/SrcNatRule.pm
+++ b/lib/Vyatta/SrcNatRule.pm
@@ -176,9 +176,11 @@ sub rule_str {
 
     if (defined($self->{_proto})) {
       my $str = $self->{_proto};
-      my $negate ="";
-      $negate = "!" if (m/^\!(.*)$/);
-      $str =~ s/^\!(.*)$/ $1/;
+      my $negate = "";
+      if ($str =~ /^\!(.*)$/) {
+        $str    = $1;
+        $negate = "!";
+      }
       if ($str eq 'tcp_udp') {
         $tcp_and_udp = 1;
         $rule_str .= " -p tcp "; # we'll add the '-p udp' to 2nd rule later


### PR DESCRIPTION
Right now ``$negate`` is always empty because ``m/^\!(.*)$/`` is matched against ``$_`` and not against ``$str``.