### PR TITLE
T1499: Allow for usage of systemd interface mappings

### DIFF
--- a/templates-cfg/nat/destination/rule/node.tag/inbound-interface/node.def
+++ b/templates-cfg/nat/destination/rule/node.tag/inbound-interface/node.def
@@ -20,7 +20,7 @@ commit:expression: exec "
              fi
              let i++
         done
-        intf_group_name_array=\"eth+ bond+ br+ peth+ vtun+ tun+ wlm+ wlan+\"
+        intf_group_name_array=\"en+ eth+ bond+ br+ peth+ vtun+ tun+ wlm+ wlan+\"
         i=0
         for i in $intf_group_name_array; do
           if [ \"$i\" == \"$VAR(@)\" ]; then

--- a/templates-cfg/nat/nptv6/rule/node.tag/outbound-interface/node.def
+++ b/templates-cfg/nat/nptv6/rule/node.tag/outbound-interface/node.def
@@ -20,7 +20,7 @@ commit:expression: exec "
              fi
              let i++
         done
-        intf_group_name_array=\"eth+ bond+ br+ peth+ vtun+ tun+ wlm+ wlan+ vxlan+ vti+ l2tpeth+\"
+        intf_group_name_array=\"en+ eth+ bond+ br+ peth+ vtun+ tun+ wlm+ wlan+ vxlan+ vti+ l2tpeth+\"
         i=0
         for i in $intf_group_name_array; do
           if [ \"$i\" == \"$VAR(@)\" ]; then

--- a/templates-cfg/nat/source/rule/node.tag/outbound-interface/node.def
+++ b/templates-cfg/nat/source/rule/node.tag/outbound-interface/node.def
@@ -20,7 +20,7 @@ commit:expression: exec "
              fi
              let i++
         done
-        intf_group_name_array=\"eth+ bond+ br+ peth+ vtun+ tun+ wlm+ wlan+\"
+        intf_group_name_array=\"en+ eth+ bond+ br+ peth+ vtun+ tun+ wlm+ wlan+\"
         i=0
         for i in $intf_group_name_array; do
           if [ \"$i\" == \"$VAR(@)\" ]; then


### PR DESCRIPTION
This PR allows the use of systemd named interfaces for ethernet.
this might get used when migrating over to buster with systemd default mappings. 